### PR TITLE
Fix Graph API path encoding

### DIFF
--- a/tests/graph-api.test.js
+++ b/tests/graph-api.test.js
@@ -1,0 +1,35 @@
+const { describe, it, expect, jest } = require('@jest/globals');
+const EventEmitter = require('events');
+
+jest.mock('https');
+
+const https = require('https');
+const { callGraphAPI } = require('../utils/graph-api');
+const config = require('../config');
+
+describe('graph-api path encoding', () => {
+  it('preserves colon slash sequences', async () => {
+    const path = '/me/drive/items/123:/foo bar.txt:/content';
+    const expectedUrl = `${config.GRAPH_API_ENDPOINT}me/drive/items/123:/foo%20bar.txt:/content`;
+
+    https.request.mockImplementation((url, options, callback) => {
+      const res = new EventEmitter();
+      res.statusCode = 200;
+      res.headers = { 'content-type': 'application/json' };
+      callback(res);
+      process.nextTick(() => {
+        res.emit('data', JSON.stringify({ ok: true }));
+        res.emit('end');
+      });
+      return {
+        on: jest.fn(),
+        write: jest.fn(),
+        end: jest.fn()
+      };
+    });
+
+    const result = await callGraphAPI('token', 'GET', path);
+    expect(https.request).toHaveBeenCalledWith(expectedUrl, expect.any(Object), expect.any(Function));
+    expect(result.ok).toBe(true);
+  });
+});

--- a/utils/graph-api.js
+++ b/utils/graph-api.js
@@ -24,10 +24,8 @@ async function callGraphAPI(accessToken, method, path, data = null, queryParams 
   try {
     console.error(`Making real API call: ${method} ${path}`);
     
-    // Encode path segments properly
-    const encodedPath = path.split('/')
-      .map(segment => encodeURIComponent(segment))
-      .join('/');
+    // Encode the entire path while preserving special characters like ':/'
+    const encodedPath = encodeURI(path);
     
     // Build query string from parameters with special handling for OData filters
     let queryString = '';


### PR DESCRIPTION
## Summary
- encode the full path in Graph API helper so characters like `:/` are preserved
- add a unit test validating `callGraphAPI` encodes paths with `:/`

## Testing
- `npm test` *(fails: jest not found)*