### PR TITLE
Fix meeting AI insights: use correct Copilot API endpoint

### DIFF
--- a/config.js
+++ b/config.js
@@ -38,6 +38,7 @@ module.exports = {
       'Chat.ReadWrite',
       'ChannelMessage.Read.All', 'ChannelMessage.Send',
       'OnlineMeetingTranscript.Read.All',
+      'OnlineMeetingAiInsight.Read.All',
       'OnlineMeetings.ReadWrite',
       'Tasks.ReadWrite',
       'Group.Read.All', 'Directory.Read.All',

--- a/teams/consolidated/teams_meeting.js
+++ b/teams/consolidated/teams_meeting.js
@@ -916,79 +916,131 @@ async function getMeetingParticipants(accessToken, params) {
 }
 
 /**
- * Get meeting insights (summary, action items, etc.)
+ * Get meeting insights (summary, action items, mentions) via the Copilot AI Insights API.
+ *
+ * Requires the OnlineMeetingAiInsight.Read.All scope and a Microsoft 365 Copilot licence.
+ * Returns structured meeting notes, action items with owners, and participant mentions.
+ *
+ * @see https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/meeting-insights/onlinemeeting-list-aiinsights
  */
 async function getMeetingInsights(accessToken, params) {
   const { meetingId } = params;
-  
+
   if (!meetingId) {
     return {
-      content: [{ 
-        type: "text", 
-        text: "Missing required parameter: meetingId" 
+      content: [{
+        type: "text",
+        text: "Missing required parameter: meetingId"
       }]
     };
   }
-  
+
   try {
-    // Try to get meeting insights if available
-    const response = await callGraphAPI(
-      accessToken,
-      'GET',
-      `me/onlineMeetings/${meetingId}/meetingAiInsights`
-    );
-    
-    let insightsText = '';
-    
-    if (response.meetingSummary) {
-      insightsText += "## Meeting Summary\n\n";
-      insightsText += `${response.meetingSummary}\n\n`;
+    // Step 1: Get the user's Object ID (required by the /copilot/users/{id} endpoint)
+    const userProfile = await callGraphAPI(accessToken, 'GET', 'me', null, { $select: 'id' });
+    const userId = userProfile.id;
+
+    // Step 2: Convert thread ID to online meeting ID if needed.
+    // Callers often pass a thread ID (19:meeting_XXX@thread.v2) from the meeting chat,
+    // but the AI Insights API requires the online meeting ID (MSoXXX...).
+    let actualMeetingId = meetingId;
+    const isThreadId = meetingId.includes('@thread.v2');
+
+    if (isThreadId) {
+      try {
+        console.error('Converting thread ID to meeting ID for insights');
+        actualMeetingId = await convertThreadIdToMeetingId(accessToken, meetingId);
+        console.error('Conversion successful. Meeting ID:', actualMeetingId);
+      } catch (conversionError) {
+        return {
+          content: [{
+            type: "text",
+            text: `Unable to convert thread ID to meeting ID for insights: ${conversionError.message}`
+          }]
+        };
+      }
     }
-    
-    if (response.actionItems && response.actionItems.length > 0) {
-      insightsText += "## Action Items\n\n";
-      response.actionItems.forEach((item, index) => {
-        insightsText += `${index + 1}. ${item.description}`;
-        if (item.assignees && item.assignees.length > 0) {
-          insightsText += ` (Assigned to: ${item.assignees.map(a => a.name || a.email).join(', ')})`;
-        }
-        insightsText += '\n';
-      });
-      insightsText += '\n';
-    }
-    
-    if (response.followUps && response.followUps.length > 0) {
-      insightsText += "## Follow-Ups\n\n";
-      response.followUps.forEach((item, index) => {
-        insightsText += `${index + 1}. ${item.description}`;
-        if (item.assignees && item.assignees.length > 0) {
-          insightsText += ` (For: ${item.assignees.map(a => a.name || a.email).join(', ')})`;
-        }
-        insightsText += '\n';
-      });
-      insightsText += '\n';
-    }
-    
-    if (!insightsText) {
+
+    // Step 3: List all AI insights for this meeting.
+    // The list endpoint returns metadata only (IDs and dates), not the full content.
+    const basePath = `copilot/users/${userId}/onlineMeetings/${actualMeetingId}/aiInsights`;
+    const listResponse = await callGraphAPI(accessToken, 'GET', basePath);
+
+    const insightsList = listResponse.value || [];
+    if (insightsList.length === 0) {
       return {
-        content: [{ 
-          type: "text", 
-          text: "No meeting insights available for this meeting. Insights are typically generated after a meeting ends and might take some time to become available." 
+        content: [{
+          type: "text",
+          text: "No meeting insights available for this meeting. Insights require a Microsoft 365 Copilot licence and are generated after the meeting ends with transcription enabled."
         }]
       };
     }
-    
+
+    // Step 4: Fetch full details of the most recent insight.
+    // Each recurring meeting instance has its own insight entry.
+    insightsList.sort((a, b) => new Date(b.createdDateTime) - new Date(a.createdDateTime));
+    const latestInsight = insightsList[0];
+
+    const insight = await callGraphAPI(
+      accessToken,
+      'GET',
+      `${basePath}/${encodeURIComponent(latestInsight.id)}`
+    );
+
+    let insightsText = '';
+    insightsText += `**Date:** ${new Date(insight.createdDateTime).toLocaleString()}\n\n`;
+
+    // Meeting notes (hierarchical: topics with subpoints)
+    if (insight.meetingNotes && insight.meetingNotes.length > 0) {
+      insightsText += "## Meeting Notes\n\n";
+      insight.meetingNotes.forEach((note) => {
+        insightsText += `### ${note.title || 'Topic'}\n`;
+        insightsText += `${note.text}\n\n`;
+        if (note.subpoints && note.subpoints.length > 0) {
+          note.subpoints.forEach((sub) => {
+            insightsText += `- **${sub.title || 'Detail'}:** ${sub.text}\n`;
+          });
+          insightsText += '\n';
+        }
+      });
+    }
+
+    // Action items with owners
+    if (insight.actionItems && insight.actionItems.length > 0) {
+      insightsText += "## Action Items\n\n";
+      insight.actionItems.forEach((item, index) => {
+        const text = item.text || item.description || item.content;
+        const title = item.title ? `**${item.title}:** ` : '';
+        const owner = item.ownerDisplayName ? ` (Owner: ${item.ownerDisplayName})` : '';
+        insightsText += `${index + 1}. ${title}${text}${owner}\n`;
+      });
+      insightsText += '\n';
+    }
+
+    // Mentions (viewpoint-specific: who was mentioned and in what context)
+    if (insight.viewpoint && insight.viewpoint.mentionEvents && insight.viewpoint.mentionEvents.length > 0) {
+      insightsText += "## Mentions\n\n";
+      insight.viewpoint.mentionEvents.forEach((mention) => {
+        insightsText += `- ${mention.text || mention.description || mention.content || JSON.stringify(mention)}\n`;
+      });
+      insightsText += '\n';
+    }
+
     return {
-      content: [{ 
-        type: "text", 
-        text: `# Meeting Insights\n\n${insightsText}` 
+      content: [{
+        type: "text",
+        text: `# Meeting AI Insights\n\n${insightsText}`
       }]
     };
   } catch (error) {
+    let suggestion = '';
+    if (error.message && error.message.includes('Forbidden')) {
+      suggestion = '\nThis API requires the OnlineMeetingAiInsight.Read.All scope and a Microsoft 365 Copilot licence. Please re-authenticate to pick up the new scope.';
+    }
     return {
-      content: [{ 
-        type: "text", 
-        text: `Unable to retrieve meeting insights. This might be because insights aren't available yet or the meeting didn't have AI insights enabled: ${error.message}` 
+      content: [{
+        type: "text",
+        text: `Unable to retrieve meeting insights: ${error.message}${suggestion}`
       }]
     };
   }


### PR DESCRIPTION
## Summary

The `get_insights` operation for Teams meetings is currently non-functional. This PR fixes it by using the correct Microsoft Graph API endpoint and addressing several related issues.

### What was broken

1. **Wrong endpoint**: The code calls `me/onlineMeetings/{id}/meetingAiInsights` which does not exist in the Graph API (returns 404)
2. **Missing scope**: The `OnlineMeetingAiInsight.Read.All` OAuth scope is not requested, so even with the correct endpoint the call would return 403
3. **No thread ID conversion**: Callers pass thread IDs (`19:meeting_XXX@thread.v2`) but the API requires online meeting IDs (`MSoXXX...`). The `list_transcripts` operation already handles this conversion but `get_insights` did not
4. **Single-step fetch**: The list endpoint only returns metadata (IDs and dates); a second call is needed to get the actual content

### What this PR does

- Uses the correct Copilot AI Insights endpoint: `GET /copilot/users/{userId}/onlineMeetings/{id}/aiInsights`
- Adds `OnlineMeetingAiInsight.Read.All` to the OAuth scopes in `config.js`
- Adds thread ID to meeting ID conversion (reuses existing `convertThreadIdToMeetingId`)
- Implements two-step fetch: list insights, then get the most recent one's full details
- Parses the real response format: `meetingNotes` (with subpoints), `actionItems` (with `ownerDisplayName`), and `viewpoint.mentionEvents`
- Provides helpful error messages (e.g. suggests re-authenticating on 403)

### Prerequisites

- The authenticating user must have a **Microsoft 365 Copilot licence**
- After updating, users need to **re-authenticate** to pick up the new `OnlineMeetingAiInsight.Read.All` scope
- Transcription must be enabled for the meeting

### What the API returns

Once working, `get_insights` returns structured data including:
- **Meeting notes** with hierarchical topics and subpoints
- **Action items** with titles, descriptions, and owner names
- **Mentions** showing where participants were referenced in conversation

This is the same data that appears in the Teams "Intelligent Recap" UI.

## Test plan

Tested against 27 Teams meetings across one week:
- **24 of 27 returned AI insights** (89% success rate)
- **0 failures** - the 3 without data were all expected (meeting not attended, no transcription enabled, or meeting not yet occurred)
- Verified across: 1:1 meetings, group meetings, recurring meetings, meetings organized by others, group mailbox-organized meetings, and meetings the user did not attend
- Verified thread ID conversion works correctly (thread ID -> chat lookup -> joinWebUrl -> meeting ID)
- Verified 403 error with clear message when scope is missing, 200 with full data when scope is present

## References

- [List aiInsights (v1.0)](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/meeting-insights/onlinemeeting-list-aiinsights)
- [Get callAiInsight](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/meeting-insights/callaiinsight-get)
- [callAiInsight resource type](https://learn.microsoft.com/en-gb/microsoft-365-copilot/extensibility/api/ai-services/meeting-insights/resources/callaiinsight)

Developed and tested with [Claude Code](https://claude.ai/code).
