### PR TITLE
Encrypt the token cache at rest with Windows DPAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,8 @@ For Windows background operation:
 
 ## Security Considerations
 
-- **Secure Token Storage**: Tokens are stored with restricted file permissions (0o600) using atomic writes to prevent corruption
+- **Encrypted Token Storage (Windows)**: On Windows the token cache (`~/.office-mcp-tokens.json`) is encrypted at rest with the Windows Data Protection API (DPAPI, CurrentUser scope) via `auth/secure-store.js` before it is written. The on-disk ciphertext is bound to the current Windows user account on this machine, so it is useless if copied to another machine/user, synced to the cloud (OneDrive), or pulled from a backup. A legacy plaintext token file is transparently migrated to the encrypted format on first read. No native build dependency is required (DPAPI is invoked through PowerShell). On non-Windows platforms it falls back to restricted-permission (0o600) plaintext with atomic writes.
+- **At-rest protection only (threat model)**: DPAPI defends against file copy/sync/backup and other users or admins reading the file; it does **not** stop malicious code already running as the same Windows user (such code can ask DPAPI to decrypt, as the server does). For device-bound (TPM) refresh tokens that never touch disk, migrate to MSAL + the Windows WAM broker.
 - **No Credential Logging**: Token content is never logged; only boolean presence checks are used
 - **Sensitive Data Redaction**: Email bodies, recipients, and search queries are not logged; API URLs with query params are gated behind DEBUG_VERBOSE
 - **Environment Variables**: Never commit `.env` files

--- a/auth/auto-refresh.js
+++ b/auth/auto-refresh.js
@@ -3,8 +3,8 @@
  * Handles refreshing access tokens using refresh tokens without user interaction
  */
 const https = require('https');
-const fs = require('fs');
 const config = require('../config');
+const secureStore = require('./secure-store');
 
 /**
  * Refreshes the access token using the stored refresh token
@@ -14,13 +14,11 @@ async function refreshAccessToken() {
   console.error('[AUTO-REFRESH] Starting token refresh process');
   
   try {
-    // Load existing tokens
-    const tokenPath = config.AUTH_CONFIG.tokenStorePath;
-    if (!fs.existsSync(tokenPath)) {
+    // Load existing tokens (transparently decrypted on Windows via secure-store)
+    const tokens = secureStore.readTokens();
+    if (!tokens) {
       throw new Error('Token file not found. Initial authentication required.');
     }
-    
-    const tokens = JSON.parse(fs.readFileSync(tokenPath, 'utf8'));
     
     if (!tokens.refresh_token) {
       throw new Error('No refresh token available. Re-authentication required.');
@@ -83,11 +81,8 @@ async function refreshAccessToken() {
                 newTokens.refresh_token = tokens.refresh_token;
               }
 
-              // Save refreshed tokens with secure permissions (atomic write)
-              const tempPath = tokenPath + '.tmp';
-              fs.writeFileSync(tempPath, JSON.stringify(newTokens, null, 2), { mode: 0o600 });
-              fs.renameSync(tempPath, tokenPath);
-              try { fs.chmodSync(tokenPath, 0o600); } catch (e) { /* Windows may not support chmod */ }
+              // Persist refreshed tokens (encrypted at rest on Windows via DPAPI)
+              secureStore.writeTokens(newTokens);
 
               console.error('[AUTO-REFRESH] Token refresh successful');
               console.error(`[AUTO-REFRESH] New token expires at: ${new Date(expiresAt).toLocaleString()}`);
@@ -150,13 +145,10 @@ function needsRefresh(tokens, bufferMinutes = 5) {
  * @returns {Promise<string>} - Valid access token
  */
 async function getValidAccessToken() {
-  const tokenPath = config.AUTH_CONFIG.tokenStorePath;
-  
-  if (!fs.existsSync(tokenPath)) {
+  let tokens = secureStore.readTokens();
+  if (!tokens) {
     throw new Error('No tokens found. Initial authentication required.');
   }
-  
-  let tokens = JSON.parse(fs.readFileSync(tokenPath, 'utf8'));
   
   if (needsRefresh(tokens)) {
     console.error('[AUTO-REFRESH] Token needs refresh, initiating refresh');

--- a/auth/secure-store.js
+++ b/auth/secure-store.js
@@ -1,0 +1,167 @@
+/**
+ * Secure token cache storage for Office MCP.
+ *
+ * On Windows, the token bundle (access_token, refresh_token, id metadata, etc.) is
+ * encrypted at rest using the Windows Data Protection API (DPAPI, CurrentUser scope)
+ * before being written to disk. Decryption is bound to the current Windows user
+ * account on this machine, so the on-disk ciphertext is useless if copied to another
+ * machine, another user profile, a backup, or a cloud-sync folder (OneDrive, etc.).
+ *
+ * DPAPI is invoked through Windows PowerShell
+ * (System.Security.Cryptography.ProtectedData), so there is NO native build
+ * dependency (no node-gyp / win-dpapi).
+ *
+ * On non-Windows platforms it falls back to the previous plaintext-at-0600 behavior.
+ * The server is primarily run on Windows; macOS/Linux operators should prefer an
+ * MSAL-based flow backed by Keychain / libsecret.
+ *
+ * THREAT MODEL: this protects tokens AT REST (file copy, cloud sync, backup, another
+ * user or admin reading the file). It does NOT defend against malicious code already
+ * running as the same Windows user, which can ask DPAPI to decrypt exactly as this
+ * module does. Use Conditional Access / token protection for that layer.
+ */
+const fs = require('fs');
+const { execFileSync } = require('child_process');
+const config = require('../config');
+
+const TOKEN_PATH = config.AUTH_CONFIG.tokenStorePath;
+const FORMAT = 'dpapi-cu-v1';
+// App-specific optional entropy mixed into DPAPI. NOT a secret; it only scopes the
+// blob to this application so unrelated CurrentUser DPAPI blobs can't be cross-used.
+const ENTROPY = 'office-mcp-token-store-v1';
+const isWindows = process.platform === 'win32';
+
+// PowerShell payload: reads base64 from stdin, runs Protect/Unprotect per
+// $env:DPAPI_MODE under CurrentUser scope with fixed app entropy, writes base64
+// result to stdout (no trailing newline via [Console]::Out.Write).
+const PS_SCRIPT = `
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+Add-Type -AssemblyName System.Security
+$mode = $env:DPAPI_MODE
+$entropy = [System.Text.Encoding]::UTF8.GetBytes('${ENTROPY}')
+$scope = [System.Security.Cryptography.DataProtectionScope]::CurrentUser
+$inB64 = [Console]::In.ReadToEnd().Trim()
+$inBytes = [System.Convert]::FromBase64String($inB64)
+if ($mode -eq 'protect') {
+  $out = [System.Security.Cryptography.ProtectedData]::Protect($inBytes, $entropy, $scope)
+} else {
+  $out = [System.Security.Cryptography.ProtectedData]::Unprotect($inBytes, $entropy, $scope)
+}
+[Console]::Out.Write([System.Convert]::ToBase64String($out))
+`;
+
+function runDpapi(mode, inputBuffer) {
+  // -EncodedCommand expects UTF-16LE base64; data flows via stdin (never the cmdline).
+  const encoded = Buffer.from(PS_SCRIPT, 'utf16le').toString('base64');
+  const stdout = execFileSync(
+    'powershell.exe',
+    ['-NoProfile', '-NonInteractive', '-EncodedCommand', encoded],
+    {
+      input: inputBuffer.toString('base64'),
+      env: { ...process.env, DPAPI_MODE: mode },
+      maxBuffer: 16 * 1024 * 1024,
+      windowsHide: true,
+    }
+  );
+  return Buffer.from(stdout.toString('utf8').trim(), 'base64');
+}
+
+function encryptToFileContents(tokensObj) {
+  const plaintext = Buffer.from(JSON.stringify(tokensObj), 'utf8');
+  const ciphertext = runDpapi('protect', plaintext);
+  return JSON.stringify({ format: FORMAT, ciphertext: ciphertext.toString('base64') }, null, 2);
+}
+
+function decryptCiphertext(ciphertextB64) {
+  const ciphertext = Buffer.from(ciphertextB64, 'base64');
+  const plaintext = runDpapi('unprotect', ciphertext);
+  return JSON.parse(plaintext.toString('utf8'));
+}
+
+function atomicWrite(contents) {
+  const tempPath = TOKEN_PATH + '.tmp';
+  fs.writeFileSync(tempPath, contents, { mode: 0o600 });
+  fs.renameSync(tempPath, TOKEN_PATH);
+  try { fs.chmodSync(TOKEN_PATH, 0o600); } catch (e) { /* Windows may not support chmod */ }
+}
+
+/**
+ * Reads and returns the token object, transparently decrypting on Windows.
+ * Transparently migrates a legacy plaintext file to encrypted-at-rest on first
+ * read (Windows only).
+ * @returns {object|null}
+ */
+function readTokens() {
+  try {
+    if (!fs.existsSync(TOKEN_PATH)) {
+      return null;
+    }
+    const raw = fs.readFileSync(TOKEN_PATH, 'utf8');
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (e) {
+      console.error('[SECURE-STORE] Token file is not valid JSON');
+      return null;
+    }
+
+    // Encrypted format
+    if (parsed && parsed.format === FORMAT && parsed.ciphertext) {
+      if (!isWindows) {
+        console.error('[SECURE-STORE] Encrypted token file found but not on Windows; cannot decrypt');
+        return null;
+      }
+      try {
+        return decryptCiphertext(parsed.ciphertext);
+      } catch (e) {
+        console.error('[SECURE-STORE] Failed to decrypt token cache (re-authentication required)');
+        return null;
+      }
+    }
+
+    // Legacy plaintext format (token fields at top level)
+    if (parsed && parsed.access_token) {
+      if (isWindows) {
+        // One-time migration: re-write encrypted at rest.
+        try {
+          atomicWrite(encryptToFileContents(parsed));
+          console.error('[SECURE-STORE] Migrated plaintext token cache to DPAPI-encrypted at rest');
+        } catch (e) {
+          console.error('[SECURE-STORE] Plaintext->encrypted migration failed (continuing):', e.message);
+        }
+      }
+      return parsed;
+    }
+
+    return null;
+  } catch (error) {
+    console.error('[SECURE-STORE] Error reading tokens:', error.message);
+    return null;
+  }
+}
+
+/**
+ * Writes the token object, encrypting at rest on Windows (plaintext 0600 elsewhere).
+ * @param {object} tokensObj
+ * @returns {boolean}
+ */
+function writeTokens(tokensObj) {
+  try {
+    const contents = isWindows
+      ? encryptToFileContents(tokensObj)
+      : JSON.stringify(tokensObj, null, 2);
+    atomicWrite(contents);
+    return true;
+  } catch (error) {
+    console.error('[SECURE-STORE] Error writing tokens:', error.message);
+    return false;
+  }
+}
+
+module.exports = {
+  readTokens,
+  writeTokens,
+  TOKEN_PATH,
+  encryptionAvailable: isWindows,
+};

--- a/auth/token-manager.js
+++ b/auth/token-manager.js
@@ -1,9 +1,8 @@
 /**
  * Token management for Microsoft Graph API authentication
  */
-const fs = require('fs');
-const config = require('../config');
 const { refreshAccessToken, needsRefresh } = require('./auto-refresh');
+const secureStore = require('./secure-store');
 
 // Global variable to store tokens
 let cachedTokens = null;
@@ -14,44 +13,36 @@ let cachedTokens = null;
  */
 function loadTokenCache() {
   try {
-    const tokenPath = config.AUTH_CONFIG.tokenStorePath;
+    // Reads + transparently decrypts (Windows DPAPI) via secure-store.
+    const tokens = secureStore.readTokens();
 
-    if (!fs.existsSync(tokenPath)) {
-      console.error('[TOKEN-MANAGER] Token file not found');
+    if (!tokens) {
+      console.error('[TOKEN-MANAGER] Token file not found or unreadable');
       return null;
     }
 
-    const tokenData = fs.readFileSync(tokenPath, 'utf8');
+    // Safe logging - only confirm presence, never log content
+    console.error('[TOKEN-MANAGER] Token loaded - has access_token:', !!tokens.access_token);
+    console.error('[TOKEN-MANAGER] Token loaded - has refresh_token:', !!tokens.refresh_token);
 
-    try {
-      const tokens = JSON.parse(tokenData);
-
-      // Safe logging - only confirm presence, never log content
-      console.error('[TOKEN-MANAGER] Token loaded - has access_token:', !!tokens.access_token);
-      console.error('[TOKEN-MANAGER] Token loaded - has refresh_token:', !!tokens.refresh_token);
-
-      if (!tokens.access_token) {
-        console.error('[TOKEN-MANAGER] No access_token found in token file');
-        return null;
-      }
-
-      // Check token expiration
-      const now = Date.now();
-      const expiresAt = tokens.expires_at || 0;
-
-      if (now > expiresAt) {
-        console.error('[TOKEN-MANAGER] Token expired - will need refresh');
-      } else {
-        const expiresIn = Math.round((expiresAt - now) / 1000 / 60);
-        console.error(`[TOKEN-MANAGER] Token valid for ~${expiresIn} minutes`);
-      }
-
-      cachedTokens = tokens;
-      return tokens;
-    } catch (parseError) {
-      console.error('[TOKEN-MANAGER] Error parsing token file');
+    if (!tokens.access_token) {
+      console.error('[TOKEN-MANAGER] No access_token found in token file');
       return null;
     }
+
+    // Check token expiration
+    const now = Date.now();
+    const expiresAt = tokens.expires_at || 0;
+
+    if (now > expiresAt) {
+      console.error('[TOKEN-MANAGER] Token expired - will need refresh');
+    } else {
+      const expiresIn = Math.round((expiresAt - now) / 1000 / 60);
+      console.error(`[TOKEN-MANAGER] Token valid for ~${expiresIn} minutes`);
+    }
+
+    cachedTokens = tokens;
+    return tokens;
   } catch (error) {
     console.error('[TOKEN-MANAGER] Error loading tokens:', error.message);
     return null;
@@ -64,29 +55,13 @@ function loadTokenCache() {
  * @returns {boolean} - Whether the save was successful
  */
 function saveTokenCache(tokens) {
-  try {
-    const tokenPath = config.AUTH_CONFIG.tokenStorePath;
-    const tempPath = tokenPath + '.tmp';
-
-    // Atomic write: write to temp file then rename to avoid corruption
-    fs.writeFileSync(tempPath, JSON.stringify(tokens, null, 2), { mode: 0o600 });
-    fs.renameSync(tempPath, tokenPath);
-
-    // Also ensure correct permissions on final file (for pre-existing files)
-    try {
-      fs.chmodSync(tokenPath, 0o600);
-    } catch (chmodError) {
-      // Windows may not support chmod, that's OK
-    }
-
+  // Encrypts at rest on Windows (DPAPI) via secure-store; atomic write inside.
+  const ok = secureStore.writeTokens(tokens);
+  if (ok) {
     console.error('[TOKEN-MANAGER] Tokens saved securely');
-
     cachedTokens = tokens;
-    return true;
-  } catch (error) {
-    console.error('[TOKEN-MANAGER] Error saving tokens:', error.message);
-    return false;
   }
+  return ok;
 }
 
 /**

--- a/office-auth-server.js
+++ b/office-auth-server.js
@@ -6,6 +6,7 @@ const os = require('os');
 const https = require('https');
 require('dotenv').config();
 const config = require('./config');
+const secureStore = require('./auth/secure-store');
 
 // MCP Server Auth Helper for Office MCP
 // This server handles the OAuth2 redirect callback from Microsoft
@@ -302,11 +303,8 @@ function exchangeCodeForTokens(code) {
             // Add expires_at for easier expiration checking
             tokenResponse.expires_at = expiresAt;
             
-            // Save tokens to file with secure permissions (atomic write)
-            const tempFile = TOKEN_FILE + '.tmp';
-            fs.writeFileSync(tempFile, JSON.stringify(tokenResponse, null, 2), { mode: 0o600 });
-            fs.renameSync(tempFile, TOKEN_FILE);
-            try { fs.chmodSync(TOKEN_FILE, 0o600); } catch (e) { /* Windows may not support chmod */ }
+            // Save tokens (encrypted at rest on Windows via DPAPI / secure-store)
+            secureStore.writeTokens(tokenResponse);
             console.log(`Tokens saved securely to ${TOKEN_FILE}`);
             
             resolve(tokenResponse);


### PR DESCRIPTION
## What
Encrypts the on-disk token cache (`~/.office-mcp-tokens.json`) at rest on Windows using the Windows Data Protection API (DPAPI, CurrentUser scope), via a new `auth/secure-store.js`. All token reads/writes — `auth/token-manager.js`, `auth/auto-refresh.js`, and `office-auth-server.js` — route through it.

## Why
Today the refresh and access tokens are written to disk in plaintext. Anyone able to copy that file (cloud sync, backup, another user/admin on the machine) gains long-lived delegated access to the mailbox. DPAPI CurrentUser binds the ciphertext to the signed-in Windows account on that machine, so a copied file is useless elsewhere.

## How
- New `auth/secure-store.js` exposing `readTokens()` / `writeTokens()`.
- DPAPI is invoked through PowerShell (`System.Security.Cryptography.ProtectedData`), so there is **no native build dependency** (no node-gyp / win-dpapi).
- A legacy plaintext token file is transparently migrated to encrypted-at-rest on first read.
- **Non-Windows platforms keep the existing plaintext-0600 behavior** (graceful fallback), so this change is additive for macOS/Linux.

## Threat model (also documented in README)
Protects tokens **at rest** (file copy, cloud sync, backup, other users reading the file). It does not defend against malicious code already running as the same Windows user. For device-bound (TPM) refresh tokens that never touch disk, MSAL + the Windows WAM broker is the natural future step.

## Tests
`npm test`: 109/110 pass. The single failure (`auditLog > should create log file with restricted permissions`) is pre-existing and unrelated to this change — it asserts a POSIX `600` file mode, which Windows does not honor (reports `666`). This PR does not touch `utils/audit.js`.

## Follow-up
A cross-platform path (macOS Keychain / Linux libsecret) via MSAL `msal-node-extensions` is a natural next step — happy to do that separately if you prefer that direction.
